### PR TITLE
thinc 8.0.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<36]
   # 2021/11/08: thinc 8.0.13 requires cython-blis >=0.4.0,<0.8.0
   # but it's not available on win32 on defaults 
   skip: True  # [win32]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - m2-patch  # [win]
+    - patch  # [not win]
   host:
     - cython
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: True  # [win and py27]
   # 2021/11/08: thinc 8.0.13 requires cython-blis >=0.4.0,<0.8.0
   # but it's not available on win32 on defaults 
   skip: True  # [win32]
@@ -20,7 +19,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - cython
+    - cython >=0.25,<3.0
     - python
     - pip
     - numpy
@@ -37,19 +36,18 @@ requirements:
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
     - cython-blis >=0.4.0,<0.8.0
-    - wasabi >=0.4.0,<1.1.0
-    - srsly >=2.0.0,<3.0.0
-    - catalogue >=0.2.0,<3.0.0
-    - pydantic >=1.7.1,<1.8.0
-    - dataclasses >=0.6,<1.0  # [py36]
-    - typing_extensions
-    - contextvars >=2.4,<3  # [py36]
+    - wasabi >=0.8.1,<1.1.0
+    - srsly >=2.4.0,<3.0.0
+    - catalogue >=2.0.4,<2.1.0
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0
+    - typing_extensions >=3.7.4.1,<4.0.0.0  # [py<=37]
 
 test:
   requires:
     - hypothesis
     - pytest
     - mock
+    - pathy >=0.3.5
   imports:
     - thinc
     - thinc.api

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,6 @@ package:
 source:
   url: https://pypi.io/packages/source/t/thinc/thinc-{{ version }}.tar.gz
   sha256: 47662a3ae33d445a77b6ea7b772444805c7bba8991f122e350daf72dedc8171a
-  patches: 0001-importorskip-tests.patch
 
 build:
   number: 0
@@ -17,8 +16,6 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - m2-patch  # [win]
-    - patch  # [not win]
   host:
     - cython
     - python
@@ -63,6 +60,7 @@ test:
 about:
   home: https://github.com/explosion/thinc/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: 'thinc: Learn super-sparse multi-class models'
   description: |
@@ -70,6 +68,7 @@ about:
     and dozens of classes. It drives https://spacy.io , a pipeline of very
     efficient NLP components. I’ve only used thinc from Cython; no real Python
     API is currently available.
+  dev_url: https://github.com/explosion/thinc/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,9 @@ build:
   # 2021/11/08: thinc 8.0.13 requires cython-blis >=0.4.0,<0.8.0
   # but it's not available on win32 on defaults 
   skip: True  # [win32]
+  # 2021/11/11: skip s390x as many dependencies are not on this platform: 
+  # e.x., preshed, cython-blis, cymem, murmurhash. 
+  skip: True  # [s390x]
 
 requirements:
   build:
@@ -29,6 +32,7 @@ requirements:
     - preshed >=3.0.2,<3.1.0
     - murmurhash >=0.28.0,<1.1.0
     - cython-blis >=0.4.0,<0.8.0
+    # On arm64 only because without it the build failed 
     - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0  # [arm64]
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,10 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  skip: true  # [win and py27]
+  skip: True  # [win and py27]
+  # 2021/11/08: thinc 8.0.13 requires cython-blis >=0.4.0,<0.8.0
+  # but it's not available on win32 on defaults 
+  skip: True  # [win32]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.1" %}
+{% set version = "8.0.13" %}
 
 package:
   name: thinc
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/thinc/thinc-{{ version }}.tar.gz
-  sha256: 88755ccd076184f29ebc29a484347830fd52a29ece58aa611faec8a578a45810
+  sha256: 47662a3ae33d445a77b6ea7b772444805c7bba8991f122e350daf72dedc8171a
   patches: 0001-importorskip-tests.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - preshed >=3.0.2,<3.1.0
     - murmurhash >=0.28.0,<1.1.0
     - cython-blis >=0.4.0,<0.8.0
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0  # [arm64]
   run:
     - python
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
Update thinc to 8.0.13

Version change: bump version number from 8.0.1 to 8.0.13
Bug Tracker: new open issues https://github.com/explosion/thinc/issues
Github releases:  https://github.com/explosion/thinc/releases
Upstream license:  License file:  https://github.com/explosion/thinc//blob/master/LICENSE
Upstream setup.cfg:  https://github.com/explosion/thinc/blob/v8.0.13/setup.cfg
Upstream setup.py:  https://github.com/explosion/thinc/blob/v8.0.13/setup.py
Upstream pyproject.toml:  https://github.com/explosion/thinc/blob/v8.0.13/pyproject.toml

The package thinc is mentioned inside the packages:
spacy |


Actions:
1. Skip `win32 `(no cython-blis >=0.4.0,<0.8.0) and `s390x `(no preshed, cython-blis, cymem, murmurhash) 
2. Update `cython`
3. Add `pydantic `in host on `arm64 `only
4. Update run dependencies
5. Add `pathy >=0.3.5` in test/requires
6. Add license_family and dev_url

Result:
- all-succeeded