### PR TITLE
thinc 8.1.10 w/ py312

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12


### PR DESCRIPTION
thinc 8.1.10 py312

**Destination channel:** defaults

### Links

- [PKG-3708]
- https://github.com/explosion/thinc

### Explanation of changes:

- re-build w/ py312


[PKG-3708]: https://anaconda.atlassian.net/browse/PKG-3708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ