### PR TITLE
thinc 8.2.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,5 @@ channels:
   - https://staging.continuum.io/prefect/fs/catalogue-feedstock/pr4/58d7da2
   # for srsly 2.4.8:
   - https://staging.continuum.io/prefect/fs/srsly-feedstock/pr8/ce69f6c
+  # for confection 0.1.4
+  - https://staging.continuum.io/prefect/fs/confection-feedstock/pr3/ad2a7b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+aggregate_branch: 3.12
+
+channels:
+  # for catalogue 2.0.10:
+  - https://staging.continuum.io/prefect/fs/catalogue-feedstock/pr4/58d7da2
+  # for srsly 2.4.8:
+  - https://staging.continuum.io/prefect/fs/srsly-feedstock/pr8/ce69f6c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  # for catalogue 2.0.10:
-  - https://staging.continuum.io/prefect/fs/catalogue-feedstock/pr4/58d7da2
-  # for srsly 2.4.8:
-  - https://staging.continuum.io/prefect/fs/srsly-feedstock/pr8/ce69f6c
-  # for confection 0.1.4
-  - https://staging.continuum.io/prefect/fs/confection-feedstock/pr3/ad2a7b8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thinc" %}
-{% set version = "8.0.15" %}
+{% set version = "8.1.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2e315020da85c3791e191fbf37c4a2433f57cf322e27380da0cd4de99d96053b
+  sha256: 6c4a48d7da07e044e84a68cbb9b22f32f8490995a2bab0bfc60e412d14afb991
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<36]
   # 2021/11/11: skip s390x as many dependencies are not on this platform: 
@@ -21,30 +21,32 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
+    - cymem 2.0.6
     - cython 0.29.32
-    - python
-    - pip
+    - cython-blis 0.7.9
+    - murmurhash 1.0.7
     - numpy {{ numpy }}
+    - pip
+    - preshed 3.0.6
+    - python
     - setuptools
     - wheel
-    - cymem 2.0.6
-    - preshed 3.0.6
-    - murmurhash 1.0.7
-    - cython-blis 0.7.7
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - murmurhash >=1.0.2,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
-    - cython-blis >=0.4.0,<0.8.0
-    - wasabi >=0.8.1,<1.1.0
+    - cython-blis >=0.7.8,<0.8.0
+    - wasabi >=0.8.1,<1.2.0
     - srsly >=2.4.0,<3.0.0
     - catalogue >=2.0.4,<2.1.0
-    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0
+    - confection >=0.0.1,<1.0.0
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.11.0
+    - packaging >=20.0
     - setuptools
     # Backports of modern Python features
-    - typing_extensions >=3.7.4.1,<4.0.0.0  # [py<38]
+    - typing_extensions >=3.7.4.1,<4.5.0  # [py<38]
 
 test:
   requires:
@@ -53,18 +55,16 @@ test:
     - mock
     - pathy >=0.3.5
     # For thinc.api
-    - packaging
     - pip
   imports:
     - thinc
     - thinc.api
+    - thinc.linear
     - thinc.extra
+    - thinc.neural
   commands:
     - pip check
-    # FileNotFoundError: [Errno 2] No such file or directory: 'gs://test-bucket/thinc_model',
-    # 'gs://test-bucket/cool_shim.data', and 'gs://test-bucket/config.cfg'
-    - python -m pytest --tb=native --pyargs thinc -k "not (test_config_roundtrip_disk_respects_path_subclasses or test_shim_can_roundtrip_with_path_subclass or test_model_can_roundtrip_with_path_subclass)"
-
+    - python -m pytest --tb=native --pyargs thinc
 about:
   home: https://thinc.ai/
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,9 +59,10 @@ test:
   imports:
     - thinc
     - thinc.api
-    - thinc.linear
+    - thinc.backends
     - thinc.extra
-    - thinc.neural
+    - thinc.layers
+    - thinc.shims
   commands:
     - pip check
     - python -m pytest --tb=native --pyargs thinc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thinc" %}
-{% set version = "8.1.10" %}
+{% set version = "8.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6c4a48d7da07e044e84a68cbb9b22f32f8490995a2bab0bfc60e412d14afb991
+  sha256: 6e85b944672c0f95241a71f67f9882e1ab319c449a47740b0d159f4cf86d1587
 
 build:
   number: 0
@@ -21,13 +21,13 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - cymem 2.0.6
-    - cython 0.29.32
-    - cython-blis 0.7.9
-    - murmurhash 1.0.7
+    - cymem
+    - cython 0.29
+    - cython-blis
+    - murmurhash
     - numpy {{ numpy }}
     - pip
-    - preshed 3.0.6
+    - preshed
     - python
     - setuptools
     - wheel
@@ -42,7 +42,7 @@ requirements:
     - srsly >=2.4.0,<3.0.0
     - catalogue >=2.0.4,<2.1.0
     - confection >=0.0.1,<1.0.0
-    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.11.0
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,<3.0.0
     - packaging >=20.0
     - setuptools
     # Backports of modern Python features
@@ -53,7 +53,8 @@ test:
     - hypothesis
     - pytest
     - mock
-    - pathy >=0.3.5
+    # Python 3.12 isn't compatible, see https://github.com/justindujardin/pathy/issues/106
+    - pathy >=0.3.5  # [py<312]
     # For thinc.api
     - pip
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<36]
-  # 2021/11/11: skip s390x as many dependencies are not on this platform: 
-  # e.x., preshed, cython-blis, cymem, murmurhash. 
+  # 2021/11/11: skip s390x as many dependencies are not on this platform:
+  # e.x., preshed, cython-blis, cymem, murmurhash.
   skip: True  # [s390x]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,13 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - cymem
-    - cython 0.29
-    - cython-blis
-    - murmurhash
+    - cymem >=2.0.2,<2.1.0
+    - cython >=0.25,<3.0
+    - cython-blis >=0.7.8,<0.8.0
+    - murmurhash >=1.0.2,<1.1.0
     - numpy {{ numpy }}
     - pip
-    - preshed
+    - preshed >=3.0.2,<3.1.0
     - python
     - setuptools
     - wheel


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3713](https://anaconda.atlassian.net/browse/PKG-3713) 
- [Upstream repository](https://github.com/explosion/thinc/blob/v8.2.2/pyproject.toml)
- Changelog: https://github.com/explosion/thinc/releases
- Requirements:
  - https://github.com/explosion/thinc/blob/v8.2.2/pyproject.toml
  - https://github.com/explosion/thinc/blob/v8.2.2/requirements.txt
  - https://github.com/explosion/thinc/blob/v8.2.2/setup.cfg
  - https://github.com/explosion/thinc/blob/v8.2.2/setup.py

### Explanation of changes:

- Remove `host` pinnings for python packages
- Update `pydantic` pinning in `run`
- Do not use `pathy` for py312 in tests because of incompatibility, see https://github.com/justindujardin/pathy/issues/106

### Notes:

- spacy 3.7.2 requires it https://github.com/AnacondaRecipes/spacy-feedstock/pull/25

[PKG-3713]: https://anaconda.atlassian.net/browse/PKG-3713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ