### PR TITLE
thinc 8.3.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/ff3408c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/ff3408c
+  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/a90ed26

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/a90ed26

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,6 @@ requirements:
     - pydantic >=1.7.4,!=1.8,!=1.8.1,<3.0.0
     - packaging >=20.0
     - setuptools
-    # Backports of modern Python features
-    - typing_extensions >=3.7.4.1,<4.5.0  # [py<38]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thinc" %}
-{% set version = "8.2.2" %}
+{% set version = "8.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6e85b944672c0f95241a71f67f9882e1ab319c449a47740b0d159f4cf86d1587
+  sha256: 3e8ef69eac89a601e11d47fc9e43d26ffe7ef682dcf667c94ff35ff690549aeb
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
   host:
     - cymem >=2.0.2,<2.1.0
     - cython >=0.25,<3.0
-    - cython-blis >=0.7.8,<0.8.0
+    - cython-blis >=1.0.0,<1.1.0
     - murmurhash >=1.0.2,<1.1.0
     - numpy {{ numpy }}
     - pip
@@ -37,7 +37,7 @@ requirements:
     - murmurhash >=1.0.2,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
-    - cython-blis >=0.7.8,<0.8.0
+    - cython-blis >=1.0.0,<1.1.0
     - wasabi >=0.8.1,<1.2.0
     - srsly >=2.4.0,<3.0.0
     - catalogue >=2.0.4,<2.1.0
@@ -50,9 +50,9 @@ requirements:
 
 test:
   requires:
-    - hypothesis
-    - pytest
-    - mock
+    - hypothesis >=3.27.0,<6.72.2
+    - pytest >=5.2.0,!=7.1.0
+    - mock >=2.0.0,<3.0.0
     # Python 3.12 isn't compatible, see https://github.com/justindujardin/pathy/issues/106
     - pathy >=0.3.5  # [py<312]
     # For thinc.api

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - cython >=0.25,<3.0
     - cython-blis >=1.0.0,<1.1.0
     - murmurhash >=1.0.2,<1.1.0
-    - numpy {{ numpy }}
+    - numpy >=2.0.0,<2.1.0
     - pip
     - preshed >=3.0.2,<3.1.0
     - python
@@ -33,7 +33,7 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=2.0.0,<2.1.0
     - murmurhash >=1.0.2,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
@@ -52,7 +52,7 @@ test:
   requires:
     - hypothesis >=3.27.0,<6.72.2
     - pytest >=5.2.0,!=7.1.0
-    - mock >=2.0.0,<3.0.0
+    - mock
     # Python 3.12 isn't compatible, see https://github.com/justindujardin/pathy/issues/106
     - pathy >=0.3.5  # [py<312]
     # For thinc.api

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<36]
+  # numpy-base >=2.0.0 requires python >=3.9
+  skip: True  # [py<39]
   # 2021/11/11: skip s390x as many dependencies are not on this platform:
   # e.x., preshed, cython-blis, cymem, murmurhash.
   skip: True  # [s390x]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5892](https://anaconda.atlassian.net/browse/PKG-5892) 
- [Upstream repository](https://github.com/explosion/thinc/tree/release-v8.3.2)
- Requirements:
  - https://github.com/explosion/thinc/blob/release-v8.3.2/pyproject.toml
  - https://github.com/explosion/thinc/blob/release-v8.3.2/setup.cfg 

### Explanation of changes:

- Skip py<39 because numpy-base >=2.0.0 requires python >=3.9
- Update pinnings

### Notes:

- `spacy 3.8.2` requires `thinc >=8.3.0,<8.4.0` https://github.com/AnacondaRecipes/spacy-feedstock/pull/26


[PKG-5892]: https://anaconda.atlassian.net/browse/PKG-5892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ