### PR TITLE
loosen numpy bounds

### DIFF
--- a/recipe/loosen-numpy-bounds.patch
+++ b/recipe/loosen-numpy-bounds.patch
@@ -1,0 +1,28 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index b8277d23..5a58d350 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,8 +6,7 @@ requires = [
+     "cymem>=2.0.2,<2.1.0",
+     "preshed>=3.0.2,<3.1.0",
+     "blis>=1.0.0,<1.1.0",
+-    "numpy>=2.0.0,<2.1.0; python_version < '3.9'",
+-    "numpy>=2.0.0,<2.1.0; python_version >= '3.9'",
++    "numpy>=2.0.0,<3.0.0",
+ ]
+ build-backend = "setuptools.build_meta"
+ 
+diff --git a/setup.cfg b/setup.cfg
+index 9f156b6..6fc5a5c 100644
+--- a/setup.cfg
++++ b/setup.cfg	
+@@ -47,8 +47,7 @@ install_requires =
+ 	catalogue>=2.0.4,<2.1.0
+ 	confection>=0.0.1,<1.0.0
+ 	setuptools
+-	numpy>=2.0.0,<2.1.0; python_version < "3.9"
+-	numpy>=2.0.0,<2.1.0; python_version >= "3.9"
++	numpy>=2.0.0,<3.0.0
+ 	pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
+ 	packaging>=20.0
+ 	dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 3e8ef69eac89a601e11d47fc9e43d26ffe7ef682dcf667c94ff35ff690549aeb
+  patches:
+    - loosen-numpy-bounds.patch
 
 build:
   number: 1
@@ -21,6 +23,8 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - patch # [unix]
+    - m2-patch # [win]
   host:
     - cymem >=2.0.2,<2.1.0
     - cython >=0.25,<3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
   run:
     - python
     # loosened bounds as per https://github.com/explosion/thinc/compare/release-v8.3.2...release-v8.3.4
-    - numpy>=1.19.0,<3.0.0
+    - numpy >=1.19.0,<3.0.0
     - murmurhash >=1.0.2,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3e8ef69eac89a601e11d47fc9e43d26ffe7ef682dcf667c94ff35ff690549aeb
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   # numpy-base >=2.0.0 requires python >=3.9
   skip: True  # [py<39]
@@ -26,7 +26,7 @@ requirements:
     - cython >=0.25,<3.0
     - cython-blis >=1.0.0,<1.1.0
     - murmurhash >=1.0.2,<1.1.0
-    - numpy >=2.0.0,<2.1.0
+    - numpy >=2.0.0,<3.0.0
     - pip
     - preshed >=3.0.2,<3.1.0
     - python
@@ -34,7 +34,8 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=2.0.0,<2.1.0
+    # loosened bounds as per https://github.com/explosion/thinc/compare/release-v8.3.2...release-v8.3.4
+    - numpy>=1.19.0,<3.0.0
     - murmurhash >=1.0.2,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
@@ -52,9 +53,6 @@ test:
     - hypothesis >=3.27.0,<6.72.2
     - pytest >=5.2.0,!=7.1.0
     - mock
-    # Python 3.12 isn't compatible, see https://github.com/justindujardin/pathy/issues/106
-    - pathy >=0.3.5  # [py<312]
-    # For thinc.api
     - pip
   imports:
     - thinc
@@ -66,6 +64,7 @@ test:
   commands:
     - pip check
     - python -m pytest --tb=native --pyargs thinc
+
 about:
   home: https://thinc.ai/
   license: MIT


### PR DESCRIPTION
thinc 8.3.2 b1

loosen numpy bounds as per https://github.com/explosion/thinc/compare/release-v8.3.2...release-v8.3.4

We are not updating to 8.3.4 because it requires a newer cython-blis which is not buildable on aarch64 at the moment.