### PR TITLE
PKG-13353-thinc-8.3.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/cython-blis-feedstock/pr10/eee95be

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/cython-blis-feedstock/pr10/eee95be

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
     - wasabi >=0.8.1,<1.2.0
-    - srsly >=2.4.0,<3.0.0
+    - srsly >=2.4.0,<3.1.0
     - catalogue >=2.0.4,<2.1.0
     - confection >=1.1.0,<2.0.0
     - setuptools
@@ -71,9 +71,8 @@ test:
     # --deselect runs after import; this file fails at import time — use --ignore.
     - pytest -v thinc/tests --ignore=thinc/tests/test_config.py  # [py==314]
   requires:
-    - hypothesis
-    - pytest
-    - mock
+    - hypothesis >=3.27.0,<6.149
+    - pytest >=5.2.0,!=7.1.0
     - pip
 
 about:
@@ -86,8 +85,8 @@ about:
     Thinc is a lightweight deep learning library that offers an elegant, type-checked, functional-programming API 
     for composing models, with support for layers defined in other frameworks 
     such as PyTorch, TensorFlow and MXNet. You can use Thinc as an interface layer, a standalone toolkit 
-    or a flexible way to develop new models. Previous versions of Thinc have been running quietly in production in thousands of companies, 
-    via both spaCy and Prodigy.
+    or a flexible way to develop new models. Previous versions of Thinc have been running quietly in production
+    in thousands of companies, via both spaCy and Prodigy.
   dev_url: https://github.com/explosion/thinc
   doc_url: https://thinc.ai/docs
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,3 +96,6 @@ extra:
     - honnibal
     - ines
     - adrianeboyd
+  skip-lints:
+    - cython_needs_compiler
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "thinc" %}
-{% set version = "8.3.10" %}
+{% set version = "8.3.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5a75109f4ee1c968fc055ce651a17cb44b23b000d9e95f04a4d047ab3cb3e34e
+  sha256: 68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<310 or py>315]
+  skip: True  # [py<310 or py>314]
 
 requirements:
   build:
@@ -21,7 +21,6 @@ requirements:
   host:
     - pip
     - python
-    - wheel
     - setuptools
     - cython >=3.0,<4.0
     - murmurhash >=1.0.2,<1.1.0
@@ -31,7 +30,6 @@ requirements:
     - numpy {{ numpy }}
   run:
     - python
-    # loosened bounds as per https://github.com/explosion/thinc/compare/release-v8.3.2...release-v8.3.6
     - numpy {{ numpy }}
     - cython-blis >=1.3.0,<1.4.0
     - murmurhash >=1.0.2,<1.1.0
@@ -40,13 +38,10 @@ requirements:
     - wasabi >=0.8.1,<1.2.0
     - srsly >=2.4.0,<3.0.0
     - catalogue >=2.0.4,<2.1.0
-    - confection >=0.0.1,<1.0.0
+    - confection >=1.1.0,<2.0.0
     - setuptools
     - pydantic >=2.0.0,<3.0.0
     - packaging >=20.0
-    - dataclasses >=0.6,<1.0  # [py<37]
-    - typing_extensions >=3.7.4.1,<5.0.0  # [py<38]
-    - contextvars >=2.4,<3  # [py<37]
   run_constrained:
     # apple
     - thinc-apple-ops >=1.0.0,<2.0.0
@@ -67,9 +62,14 @@ test:
     - thinc.extra
     - thinc.layers
     - thinc.shims
+  source_files:
+    - thinc/tests/
   commands:
     - pip check
-    - python -m pytest --tb=native --pyargs thinc
+    - pytest -v thinc/tests  # [py<314]
+    # Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
+    # --deselect runs after import; this file fails at import time — use --ignore.
+    - pytest -v thinc/tests --ignore=thinc/tests/test_config.py  # [py==314]
   requires:
     - hypothesis
     - pytest
@@ -97,6 +97,3 @@ extra:
     - honnibal
     - ines
     - adrianeboyd
-  skip-lints:
-    - cython_needs_compiler
-    - python_build_tool_in_run


### PR DESCRIPTION
thinc 8.3.13

**Destination channel:** Defaults

### Links

- [PKG-13353](https://anaconda.atlassian.net/browse/PKG-13353)
- dev_url: https://github.com/explosion/thinc/tree/v8.3.13
- conda_forge: https://github.com/conda-forge/thinc-feedstock
- pypi: https://pypi.org/project/thinc/8.3.13/

### Explanation of changes:

- update 8.3 version to the latest patch
- add py314 build
- this is a dependency for the latest `spacy`

[PKG-13353]: https://anaconda.atlassian.net/browse/PKG-13353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ